### PR TITLE
fix: unexpected body when get/head method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const gmFetch: typeof fetch = async (input, init) => {
         method: request.method.toUpperCase(),
         url: request.url || location.href,
         headers,
-        data,
+        data: data.size ? data : null,
         redirect: request.redirect,
         binary: true,
         nocache: request.cache === "no-store",


### PR DESCRIPTION
在get等不能有body的请求中，抛异常：“Failed to execute 'fetch' on 'WorkerGlobalScope': Request with GET/HEAD method cannot have body.”

![image](https://github.com/user-attachments/assets/e4c77f29-f696-47ac-af30-560e35f922ce)

可以使用之前的 debug 代码复现。
https://github.com/rachpt/debug-gm-fetch

```js
const req = new Request('https://github.com/Sec-ant/gm-fetch')

req.blob().then(r => fetch(req, { body:r })).catch(e => console.log(e))
// result:  TypeError: Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.

```